### PR TITLE
Tests in t/basic.t are not passing, causing installation failure.

### DIFF
--- a/lib/File/LibMagic.pm6
+++ b/lib/File/LibMagic.pm6
@@ -46,7 +46,7 @@ my class Cookie is repr('CPointer') {
         self.setflags($flags);
         # We need the .Str to turn things like an IO::Path into an actual Str
         # for the benefit of NativeCall.
-        return magic_file( self, $filename.Str )
+        return magic_file( self, $filename.IO.resolve.Str )
             // self.throw-error;
     }
     sub magic_file (Cookie, Str) returns Str is native('magic', v1) { * }
@@ -88,29 +88,29 @@ has int32 $!flags;
 has Cool @magic-files;
 
 # Copied from /usr/include/magic.h on my system
-my \MAGIC_NONE               = 0x000000; #  No flags 
-my \MAGIC_DEBUG              = 0x000001; #  Turn on debugging 
-my \MAGIC_SYMLINK            = 0x000002; #  Follow symlinks 
-my \MAGIC_COMPRESS           = 0x000004; #  Check inside compressed files 
-my \MAGIC_DEVICES            = 0x000008; #  Look at the contents of devices 
-my \MAGIC_MIME_TYPE          = 0x000010; #  Return the MIME type 
-my \MAGIC_CONTINUE           = 0x000020; #  Return all matches 
-my \MAGIC_CHECK              = 0x000040; #  Print warnings to stderr 
-my \MAGIC_PRESERVE_ATIME     = 0x000080; #  Restore access time on exit 
-my \MAGIC_RAW                = 0x000100; #  Don't translate unprintable chars 
-my \MAGIC_ERROR              = 0x000200; #  Handle ENOENT etc as real errors 
-my \MAGIC_MIME_ENCODING      = 0x000400; #  Return the MIME encoding 
+my \MAGIC_NONE               = 0x000000; #  No flags
+my \MAGIC_DEBUG              = 0x000001; #  Turn on debugging
+my \MAGIC_SYMLINK            = 0x000002; #  Follow symlinks
+my \MAGIC_COMPRESS           = 0x000004; #  Check inside compressed files
+my \MAGIC_DEVICES            = 0x000008; #  Look at the contents of devices
+my \MAGIC_MIME_TYPE          = 0x000010; #  Return the MIME type
+my \MAGIC_CONTINUE           = 0x000020; #  Return all matches
+my \MAGIC_CHECK              = 0x000040; #  Print warnings to stderr
+my \MAGIC_PRESERVE_ATIME     = 0x000080; #  Restore access time on exit
+my \MAGIC_RAW                = 0x000100; #  Don't translate unprintable chars
+my \MAGIC_ERROR              = 0x000200; #  Handle ENOENT etc as real errors
+my \MAGIC_MIME_ENCODING      = 0x000400; #  Return the MIME encoding
 my \MAGIC_MIME               = (MAGIC_MIME_TYPE +| MAGIC_MIME_ENCODING);
-my \MAGIC_APPLE              = 0x000800; #  Return the Apple creator and type 
-my \MAGIC_NO_CHECK_COMPRESS  = 0x001000; #  Don't check for compressed files 
-my \MAGIC_NO_CHECK_TAR       = 0x002000; #  Don't check for tar files 
-my \MAGIC_NO_CHECK_SOFT      = 0x004000; #  Don't check magic entries 
-my \MAGIC_NO_CHECK_APPTYPE   = 0x008000; #  Don't check application type 
-my \MAGIC_NO_CHECK_ELF       = 0x010000; #  Don't check for elf details 
-my \MAGIC_NO_CHECK_TEXT      = 0x020000; #  Don't check for text files 
-my \MAGIC_NO_CHECK_CDF       = 0x040000; #  Don't check for cdf files 
-my \MAGIC_NO_CHECK_TOKENS    = 0x100000; #  Don't check tokens 
-my \MAGIC_NO_CHECK_ENCODING  = 0x200000; #  Don't check text encodings 
+my \MAGIC_APPLE              = 0x000800; #  Return the Apple creator and type
+my \MAGIC_NO_CHECK_COMPRESS  = 0x001000; #  Don't check for compressed files
+my \MAGIC_NO_CHECK_TAR       = 0x002000; #  Don't check for tar files
+my \MAGIC_NO_CHECK_SOFT      = 0x004000; #  Don't check magic entries
+my \MAGIC_NO_CHECK_APPTYPE   = 0x008000; #  Don't check application type
+my \MAGIC_NO_CHECK_ELF       = 0x010000; #  Don't check for elf details
+my \MAGIC_NO_CHECK_TEXT      = 0x020000; #  Don't check for text files
+my \MAGIC_NO_CHECK_CDF       = 0x040000; #  Don't check for cdf files
+my \MAGIC_NO_CHECK_TOKENS    = 0x100000; #  Don't check tokens
+my \MAGIC_NO_CHECK_ENCODING  = 0x200000; #  Don't check text encodings
 
 submethod BUILD (:@!magic-files = (), *%flag-args) {
     $!flags = 0;

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,6 +2,8 @@ use v6;
 use lib 'lib';
 use Test;
 
+plan 2;
+
 use File::LibMagic;
 
 {
@@ -82,7 +84,7 @@ sub test-flm (File::LibMagic $magic, %tests) {
                 );
             }, 'from-buffer';
 
-            subtest { 
+            subtest {
                 my $handle = $file.IO.open(:r);
                 test-info(
                     %test,


### PR DESCRIPTION
- Fixes issue with file loading. Without calling IO.resolve, symlinks are not followed and the tests in t/basic.t will fail.